### PR TITLE
fix region toggling (cookie variant)

### DIFF
--- a/app/root.tsx
+++ b/app/root.tsx
@@ -17,9 +17,10 @@ import {
   useNavigate,
   useNavigation,
   useRouteLoaderData,
+  useSubmit,
 } from "@remix-run/react";
 import { Analytics } from "@vercel/analytics/react";
-import { useEffect, useRef } from "react";
+import { FormEventHandler, useEffect, useRef } from "react";
 
 import stylesheet from "~/tailwind.css";
 
@@ -201,66 +202,45 @@ function Nav() {
 }
 
 function RegionToggle() {
+  const submit = useSubmit();
   const routeData = useRouteLoaderData("routes/$season/index");
 
+  const handleChange: FormEventHandler<HTMLFormElement> = (event) => {
+    submit(event.currentTarget, { replace: true });
+  };
+
   return (
-    <ul className="flex flex-col space-y-2 px-4 pt-4 md:flex-row md:space-x-2 md:space-y-0 md:px-0 md:pt-0">
-      {orderedRegionsBySize.map((region) => {
-        // @ts-expect-error type EnhancedSeason
-        const checked = routeData.regionsToDisplay.includes(region);
-        // @ts-expect-error type EnhancedSeason
-        const disabled = routeData.regionsToDisplay.length === 1 && checked;
+    <Form action="/regions" method="post" onChange={handleChange}>
+      <ul className="flex flex-col space-y-2 px-4 pt-4 md:flex-row md:space-x-2 md:space-y-0 md:px-0 md:pt-0">
+        {orderedRegionsBySize.map((region) => {
+          // @ts-expect-error type EnhancedSeason
+          const checked = routeData.regionsToDisplay.includes(region);
+          // @ts-expect-error type EnhancedSeason
+          const disabled = routeData.regionsToDisplay.length === 1 && checked;
 
-        return (
-          <li key={region} className={`${linkClassName}`}>
-            <label
-              className={disabled ? notAllowed : "cursor-pointer"}
-              htmlFor={`toggle-${region}`}
-            >
-              {region.toUpperCase()}
-            </label>
+          return (
+            <li key={region} className={`${linkClassName}`}>
+              <label
+                className={disabled ? notAllowed : "cursor-pointer"}
+                htmlFor={`toggle-${region}`}
+              >
+                {region.toUpperCase()}
+              </label>
 
-            <input
-              disabled={disabled}
-              type="checkbox"
-              className={disabled ? notAllowed : "cursor-pointer"}
-              id={`toggle-${region}`}
-              defaultChecked={checked}
-              aria-labelledby={`toggle-${region}`}
-              onClick={() => {
-                const activeRegions =
-                  document.cookie
-                    .split("; ")
-                    .find((row) => row.startsWith("regions"))
-                    ?.split("=")[1]
-                    ?.split(",") ?? [];
-
-                const next = activeRegions?.includes(region)
-                  ? activeRegions.filter((r) => r !== region)
-                  : [...activeRegions, region];
-
-                new Promise((resolve) => {
-                  if ("cookieStore" in window) {
-                    // @ts-expect-error experimental, not all browsers support it
-                    window.cookieStore
-                      .set("regions", next.join(","))
-                      .then(resolve);
-                  } else {
-                    // eslint-disable-next-line unicorn/no-document-cookie
-                    document.cookie = `regions=${next.join(",")}`;
-                    resolve(undefined);
-                  }
-                })
-                  .then(() => {
-                    window.location.reload();
-                  })
-                  .catch(console.error);
-              }}
-            />
-          </li>
-        );
-      })}
-    </ul>
+              <input
+                disabled={disabled}
+                type="checkbox"
+                className={disabled ? notAllowed : "cursor-pointer"}
+                id={`toggle-${region}`}
+                defaultChecked={checked}
+                aria-labelledby={`toggle-${region}`}
+                name={region}
+              />
+            </li>
+          );
+        })}
+      </ul>
+    </Form>
   );
 }
 

--- a/app/routes/$season/index.tsx
+++ b/app/routes/$season/index.tsx
@@ -5,30 +5,33 @@ import {
   type HeadersFunction,
   type LoaderFunction,
 } from "@remix-run/server-runtime";
-import {
+import Highcharts, {
   type Options,
   type PointLabelObject,
   type SeriesLineOptions,
   type XAxisPlotBandsOptions,
   type YAxisPlotLinesOptions,
 } from "highcharts";
-import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
 import { Fragment, useEffect, useRef } from "react";
 
 import { getAffixIconUrl, getAffixName } from "~/affixes";
-import { calculateXAxisPlotLines } from "~/load.server";
 import {
   calculateExtrapolation,
+  calculateXAxisPlotLines,
   calculateZoom,
   determineExtrapolationEnd,
   determineRegionsToDisplay,
+  loadDataForRegion,
+  regionsToDisplayCookie,
 } from "~/load.server";
-import { loadDataForRegion } from "~/load.server";
 import { calculateFactionDiffForWeek } from "~/utils";
 
-import { type EnhancedSeason } from "../../seasons";
-import { findSeasonByName, hasSeasonEndedForAllRegions } from "../../seasons";
+import {
+  type EnhancedSeason,
+  findSeasonByName,
+  hasSeasonEndedForAllRegions,
+} from "../../seasons";
 
 const factionColors = {
   alliance: "#60a5fa",
@@ -98,7 +101,7 @@ export const loader: LoaderFunction = async ({ params, request }) => {
   }
 
   const extrapolationEnd = determineExtrapolationEnd(request.url);
-  const regions = determineRegionsToDisplay(request.headers.get("Cookie") ?? request.headers.get('cookie'));
+  const regions = await determineRegionsToDisplay(request);
 
   const enhancedSeason: EnhancedSeason = {
     ...season,
@@ -186,7 +189,9 @@ export const loader: LoaderFunction = async ({ params, request }) => {
   ]
     .filter(Boolean)
     .join("-");
-  headers[setCookie] = `regions=${regions.join(",")}`;
+  headers[setCookie] = await regionsToDisplayCookie.serialize(
+    regions.join(",")
+  );
 
   return json(enhancedSeason, { headers });
 };

--- a/app/routes/regions.ts
+++ b/app/routes/regions.ts
@@ -1,0 +1,19 @@
+import { ActionFunction, redirect } from "@remix-run/node";
+import {
+  determineRegionsFromFormData,
+  regionsToDisplayCookie,
+} from "~/load.server";
+
+const setCookie = "Set-Cookie";
+export const action: ActionFunction = async ({ request }) => {
+  const headers: HeadersInit = {};
+
+  const bodyData = await request.formData();
+
+  const regions = await determineRegionsFromFormData(bodyData);
+  headers[setCookie] = await regionsToDisplayCookie.serialize(
+    regions.join(",")
+  );
+
+  return redirect(request.headers.get("referer") ?? "/", { headers });
+};


### PR DESCRIPTION
add `/regions` route with an action. hitting the `/regions` endpoint with a POST will set the "regions" cookie to only include regions that were marked as being "on" in the form data provided.

use refs to grab the values of every single input in the region toggle on change, then submit to the `/regions` endpoint.

this variant has an issue where you will not get an updated page upon "re-enabling" a specific region due to the page being cached for up to 30 minutes. in order to make this variant feel satisfactory, the way that caching is done may need to be revisited.