### PR TITLE
fix region toggling (url variant)

### DIFF
--- a/app/load.server.ts
+++ b/app/load.server.ts
@@ -2,8 +2,7 @@ import { Regions } from "@prisma/client";
 import { type XAxisPlotLinesOptions } from "highcharts";
 
 import { prisma } from "./prisma.server";
-import { type Dataset, type EnhancedSeason } from "./seasons";
-import { type Season } from "./seasons";
+import { type Dataset, type EnhancedSeason, type Season } from "./seasons";
 import { calculateFactionDiffForWeek, orderedRegionsBySize } from "./utils";
 
 const oneWeekInMs = 7 * 24 * 60 * 60 * 1000;
@@ -94,28 +93,18 @@ export const loadDataForRegion = async (
     .sort((a, b) => a.ts - b.ts);
 };
 
-export const determineRegionsToDisplay = (
-  cookies: string | null
-): Regions[] => {
-  if (!cookies) {
+export const determineRegionsToDisplay = async (
+  request: Request
+): Promise<Regions[]> => {
+  const params = new URL(request.url).searchParams;
+  const possiblyRegions = params.get("regions");
+
+  if (!possiblyRegions) {
     return orderedRegionsBySize;
   }
 
-  const rows = cookies.split("; ");
-  const matchingRow = rows.find((row) => row.includes("regions="));
-
-  if (!matchingRow) {
-    return orderedRegionsBySize;
-  }
-
-  const [, maybeRegionsString = ""] = matchingRow.split("=");
-
-  if (!maybeRegionsString) {
-    return orderedRegionsBySize;
-  }
-
-  const maybeRegions = maybeRegionsString
-    .split(",")
+  const maybeRegions = possiblyRegions
+    .split("~")
     .filter((maybeRegion): maybeRegion is Regions => maybeRegion in Regions);
 
   if (maybeRegions.length === 0) {
@@ -123,6 +112,11 @@ export const determineRegionsToDisplay = (
   }
 
   return maybeRegions;
+};
+export const determineRegionsFromFormData = async (
+  formData: FormData
+): Promise<Regions[]> => {
+  return orderedRegionsBySize.filter((region) => formData.get(region) === "on");
 };
 
 export const determineExtrapolationEnd = (url: string): number | null => {

--- a/app/routes/$season/index.tsx
+++ b/app/routes/$season/index.tsx
@@ -5,30 +5,32 @@ import {
   type HeadersFunction,
   type LoaderFunction,
 } from "@remix-run/server-runtime";
-import {
+import Highcharts, {
   type Options,
   type PointLabelObject,
   type SeriesLineOptions,
   type XAxisPlotBandsOptions,
   type YAxisPlotLinesOptions,
 } from "highcharts";
-import Highcharts from "highcharts";
 import HighchartsReact from "highcharts-react-official";
 import { Fragment, useEffect, useRef } from "react";
 
 import { getAffixIconUrl, getAffixName } from "~/affixes";
-import { calculateXAxisPlotLines } from "~/load.server";
 import {
   calculateExtrapolation,
+  calculateXAxisPlotLines,
   calculateZoom,
   determineExtrapolationEnd,
   determineRegionsToDisplay,
+  loadDataForRegion,
 } from "~/load.server";
-import { loadDataForRegion } from "~/load.server";
 import { calculateFactionDiffForWeek } from "~/utils";
 
-import { type EnhancedSeason } from "../../seasons";
-import { findSeasonByName, hasSeasonEndedForAllRegions } from "../../seasons";
+import {
+  type EnhancedSeason,
+  findSeasonByName,
+  hasSeasonEndedForAllRegions,
+} from "../../seasons";
 
 const factionColors = {
   alliance: "#60a5fa",
@@ -98,7 +100,7 @@ export const loader: LoaderFunction = async ({ params, request }) => {
   }
 
   const extrapolationEnd = determineExtrapolationEnd(request.url);
-  const regions = determineRegionsToDisplay(request.headers.get("Cookie") ?? request.headers.get('cookie'));
+  const regions = await determineRegionsToDisplay(request);
 
   const enhancedSeason: EnhancedSeason = {
     ...season,
@@ -186,7 +188,6 @@ export const loader: LoaderFunction = async ({ params, request }) => {
   ]
     .filter(Boolean)
     .join("-");
-  headers[setCookie] = `regions=${regions.join(",")}`;
 
   return json(enhancedSeason, { headers });
 };

--- a/app/routes/regions.ts
+++ b/app/routes/regions.ts
@@ -1,0 +1,28 @@
+import { ActionFunction, redirect } from "@remix-run/node";
+import { determineRegionsFromFormData } from "~/load.server";
+import type { Regions } from "@prisma/client";
+
+const addRegionsToReferrerOrBaseUrl = (
+  request: Request,
+  regions: Regions[]
+) => {
+  const referer = request.headers.get("Referer");
+  if (referer) {
+    const refererAsUrl = new URL(referer);
+    refererAsUrl.searchParams.set("regions", regions.join("~"));
+    return refererAsUrl.toString();
+  } else {
+    const searchParams = new URLSearchParams({ regions: regions.join(",") });
+    return `/?${searchParams.toString()}`;
+  }
+};
+
+export const action: ActionFunction = async ({ request }) => {
+  const headers: HeadersInit = {};
+
+  const bodyData = await request.formData();
+
+  const regions = await determineRegionsFromFormData(bodyData);
+
+  return redirect(addRegionsToReferrerOrBaseUrl(request, regions), { headers });
+};

--- a/app/utils.ts
+++ b/app/utils.ts
@@ -1,6 +1,6 @@
-import  { type Regions } from "@prisma/client";
+import { type Regions } from "@prisma/client";
 
-import  { type Dataset} from "./seasons";
+import { type Dataset } from "./seasons";
 import { type Season } from "./seasons";
 
 export const calculateFactionDiffForWeek = (
@@ -72,3 +72,6 @@ export const calculateFactionDiffForWeek = (
 };
 
 export const orderedRegionsBySize: Regions[] = ["eu", "us", "tw", "kr"];
+
+export const isNotNull = <T>(something: T | null): something is T =>
+  something !== null;


### PR DESCRIPTION
add `/regions` route with an action. hitting the `/regions` endpoint with a POST will set the "regions" cookie to only include regions that were marked as being "on" in the form data provided.

use refs to grab the values of every single input in the region toggle on change, then submit to the `/regions` endpoint.

this variant does not suffer from the caching issue as it changes what's requested directly. it, however, does not use cookies.